### PR TITLE
Add post for January 2013 meetup

### DIFF
--- a/content/posts/2013-01-24_january-meetup.md
+++ b/content/posts/2013-01-24_january-meetup.md
@@ -1,0 +1,9 @@
+Title: January 2013 Meetup
+Date: 2013-01-24
+Tags: regular-meetup, social
+Slug: january-2013-meetup
+Author: Trey Hunner
+
+David Fischer presented on Python modules (PyPI, pip, and virtualenv) and Trey Hunner presented on [pdb (The Python Debugger)][pdb]
+
+[pdb]: https://github.com/pythonsd/presentations/tree/2013-01-24-pdb/import%20pdb%3B%20pdb.set_trace()


### PR DESCRIPTION
This is starts the post for the January meetup.  My pdb talk material is in the presentations repository so I've linked it in the post (using 2013-01-24-pdb git tag).

@davidfischer feel free to modify the post however and add your material if you put anything online about your talk.  Your talk was pretty free form, but maybe we should link to some of the resources you talked about at least.

By the way we should use http://ascii.io/ to capture future terminal-based demos.  It's awesome.
