### PR TITLE
Added job posting guidelines finally

### DIFF
--- a/content/pages/job-posting-guidelines.md
+++ b/content/pages/job-posting-guidelines.md
@@ -1,0 +1,38 @@
+Title: Job Posting Guidelines
+
+
+Would you like to get your job posting in front of over 700 local developers?
+Here are the steps and guidelines for posting your open position:
+
+* The job posting must relate to Python in some way. This is the San Diego
+  **Python** group after all.
+* The job must be available to someone living in the greater San Diego area.
+  Commutable parts of Orange and Riverside counties as well as remote jobs
+  are all OK.
+* The subject line must make it clear that it is a job posting.
+* Please be clear whether this is a full-time or part-time job.
+
+Once you've crafted your job posting, send it in an email to
+[PythonSD-list@meetup.com][email] from the same address you used to join the
+[Meetup.com group][meetup-group]. These postings work best without attachments.
+There's a slight delay as all messages require approval.
+
+[email]: mailto:PythonSD-list@meetup.com
+[meetup-group]: http://meetup.com/pythonsd
+
+
+San Diego Python also sends out a newsletter on a monthly basis that includes
+job postings. If you would like your job posting featured in our newsletter,
+please send it to [sandiegopython@gmail.com][]. See the
+[newsletter from June 2014][june-newsletter] for an example of a past
+newsletter.
+
+[sandiegopython@gmail.com]: mailto:sandiegopython@gmail.com
+[june-newsletter]: http://pythonsd.org/june-newsletter-2014.html
+
+
+Posting a job opening is free but if you find excellent developers through
+San Diego Python, please consider a [donation][] to San Diego Python. Your
+tax deductible donations go entirely toward running our periodic workshops.
+
+[donation]: https://psfmember.org/civicrm/contribute/transact?reset=1&id=9

--- a/content/static/home.html
+++ b/content/static/home.html
@@ -10,7 +10,7 @@
 
   <div style="margin-top: 30px;">
     <h2>Hire a Pythonista</h2>
-    <p>Are you looking to hire a Python developer in San Diego? You can get your posting in front of over 600 members of the San Diego Python community for free. Join the <a href="http://meetup.com/pythonsd">Meetup group</a> and send a description of your opening to our <a href="mailto:PythonSD-list@meetup.com">mailing list</a>. You must send the email from the same address used to register with Meetup. Please specify whether the job is freelance or full-time and try to give as much detail as possible. Be concise and respectful.</p>
+    <p>Are you looking to hire a Python developer in San Diego? You can get your posting in front of over 700 members of the San Diego Python community for free. See our <a href="./pages/job-posting-guidelines.html">Job posting guidelines</a> for more details.</p>
   </div>
 
   <div style="margin-top: 30px;">


### PR DESCRIPTION
This is "heavily influenced" by the Boston Python groups job posting guidelines: http://www.meetup.com/bostonpython/pages/Job_Posting_requirements/

Any thoughts? I left off the part about no mystery jobs hiding behind a recruiter. Any thoughts on whether we should add that back in?
