### PR TITLE
Make navigation links stand out more

### DIFF
--- a/themes/sandiegopython/static/local.css
+++ b/themes/sandiegopython/static/local.css
@@ -24,7 +24,7 @@
 }
 
 .navbar .nav > li > a {
-  color: #49AFCD;
+  color: #FFFF8F;
   text-shadow: none;
 }
 .navbar .nav > li > a:hover, .navbar .nav > li > a:active {


### PR DESCRIPTION
When I tell people to go to the homepage and click the Chat Room link, they can never find it until I tell them there are links in the top navigation bar.  Blue on blue is hard to see.