### PR TITLE
Remove the footer from the meetup widget

### DIFF
--- a/themes/sandiegopython/templates/base.html
+++ b/themes/sandiegopython/templates/base.html
@@ -22,6 +22,10 @@
         color: white;
         text-shadow: none;
       }
+      #meetup_widget .mup-ft {
+        /* Meetup widget has a broken footer - hide it */
+        display: none;
+      }
       p {
         font-size: 0.9em;
       }


### PR DESCRIPTION
<img width="1008" alt="meetup-widget" src="https://cloud.githubusercontent.com/assets/185043/18170568/9d479dd0-7013-11e6-9e2d-8c1f4b79d23f.png">

I took a look at where the [meetup widget was generated](https://www.meetup.com/meetup_api/foundry/) and it appears to be broken.

Thoughts?
