### PR TITLE
Make the site links go to HTTPS

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,7 +3,7 @@
 
 AUTHOR = u'San Diego Python'
 SITENAME = u'San Diego Python'
-SITEURL = 'http://www.pythonsd.org'
+SITEURL = 'https://www.pythonsd.org'
 
 TIMEZONE = 'America/Los_Angeles'
 


### PR DESCRIPTION
I have verified the domain on Heroku but Pelican generates links to the static resources (JS/CSS/etc.) over plain HTTP. This change fixes that.

Fixes https://github.com/pythonsd/pythonsd.org/issues/106