### PR TITLE
Make some theme links HTTPS instead of HTTP

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -16,10 +16,10 @@ TEMPLATE_PAGES = {
 # Social widget
 # Icons are in themes/sandiegopython/static/images/icons
 SOCIAL = (
-    ('meetup', 'http://meetup.com/pythonsd'),
-    ('twitter', 'http://twitter.com/sandiegopython'),
+    ('meetup', 'https://meetup.com/pythonsd'),
+    ('twitter', 'https://twitter.com/sandiegopython'),
     ('google group', 'https://groups.google.com/group/pythonsd'),
-    ('github', 'http://github.com/pythonsd'),
+    ('github', 'https://github.com/pythonsd'),
     ('irc', 'irc://irc.freenode.net/sandiegopython'),
     ('slack', 'https://pythonsd.slack.com/'),
 )

--- a/themes/sandiegopython/templates/base.html
+++ b/themes/sandiegopython/templates/base.html
@@ -92,7 +92,7 @@
 
             <div class="well" style="padding: 8px 0; background-color: #FBFBFB;">
                 <!-- Meetup Widget: https://www.meetup.com/meetup_api/foundry/ -->
-                <iframe width="218" height="350" src="http://meetu.ps/3ccdby" frameborder="0" class="pagination-centered"></iframe>
+                <iframe width="218" height="350" src="https://meetu.ps/3ccdby" frameborder="0" class="pagination-centered"></iframe>
             </div>
 
             <div class="well" style="padding: 8px 0; background-color: #FBFBFB;">
@@ -166,7 +166,7 @@
 
 
 </div> <!-- /container -->
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 <script src="{{ SITEURL }}/theme/bootstrap.min.js"></script>
 
 {% include "analytics.html" %}


### PR DESCRIPTION
This purposefully doesn't change anything in content/. There's a lot of HTTP links in there and each one would need to be verified.

This changes the meetup link but the meetup widget is still broken after merging this. It will at least load, however.