### PR TITLE
Add a new meetup.com upcoming events widget

### DIFF
--- a/themes/sandiegopython/static/meetup-widget.js
+++ b/themes/sandiegopython/static/meetup-widget.js
@@ -1,0 +1,17 @@
+// Meetup widget
+//
+// Display upcoming SD Python events in the sidebar
+// Load the meetup widget if there is a div for it (#meetup-widget)
+$(document).ready(function () {
+    var WIDGET_CONTAINER = "#meetup-widget";
+
+    if ($(WIDGET_CONTAINER).length) {
+        $.ajax({
+            dataType: "html",
+            url: "https://www.pythonsd.org/meetup-widget.html",
+            success: function (data) {
+                $(WIDGET_CONTAINER).append(data);
+            }
+        });
+    }
+});

--- a/themes/sandiegopython/templates/base.html
+++ b/themes/sandiegopython/templates/base.html
@@ -22,10 +22,6 @@
         color: white;
         text-shadow: none;
       }
-      #meetup_widget .mup-ft {
-        /* Meetup widget has a broken footer - hide it */
-        display: none;
-      }
       p {
         font-size: 0.9em;
       }
@@ -91,8 +87,10 @@
             {% endif %}
 
             <div class="well" style="padding: 8px 0; background-color: #FBFBFB;">
-                <!-- Meetup Widget: https://www.meetup.com/meetup_api/foundry/ -->
-                <iframe width="218" height="350" src="https://meetu.ps/3ccdby" frameborder="0" class="pagination-centered"></iframe>
+                <!-- Meetup Widget -->
+                <ul class="nav nav-list" id="meetup-widget">
+                    <li class="nav-header">Upcoming events</li>
+                </ul>
             </div>
 
             <div class="well" style="padding: 8px 0; background-color: #FBFBFB;">
@@ -168,6 +166,7 @@
 </div> <!-- /container -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 <script src="{{ SITEURL }}/theme/bootstrap.min.js"></script>
+<script src="{{ SITEURL }}/theme/meetup-widget.js"></script>
 
 {% include "analytics.html" %}
 {% include "github.html" %}


### PR DESCRIPTION
This widget hits the Django site meetup.com widget implemented in https://github.com/pythonsd/pythonsd-django/pull/26

Fixes #110 

## Testing locally

Until https://github.com/pythonsd/pythonsd-django/pull/28 is merged and deployed, you'll need to run the django site locally and update the URL in `meetup-widget.js` in order to hit your local instance instead of the production instance.


## Screenshot

![Screen Shot 2019-10-09 at 9 03 52 AM](https://user-images.githubusercontent.com/185043/66498954-c3e1bb00-ea73-11e9-9d6d-2f639737075e.png)
